### PR TITLE
Bug fixes with schema generation and data coercion

### DIFF
--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -46,9 +46,9 @@ def discover(config):
         try:
             modified_since = dateutil.parser.parse(table_spec['start_date'])
             target_files = file_utils.get_matching_objects(table_spec, modified_since)
-            sample_rate = table_spec.get('sample_rate',10)
+            sample_rate = table_spec.get('sample_rate',5)
             max_sampling_read = table_spec.get('max_sampling_read', 1000)
-            max_sampled_files = table_spec.get('max_sampled_files', 5)
+            max_sampled_files = table_spec.get('max_sampled_files', 50)
             prefer_number_vs_integer = table_spec.get('prefer_number_vs_integer', False)
             samples = file_utils.sample_files(table_spec, target_files,sample_rate=sample_rate,
                                               max_records=max_sampling_read, max_files=max_sampled_files)

--- a/tap_spreadsheets_anywhere/conversion.py
+++ b/tap_spreadsheets_anywhere/conversion.py
@@ -1,16 +1,18 @@
 import dateutil
 import pytz
 import logging
+from copy import deepcopy
 
 LOGGER = logging.getLogger(__name__)
 
 
 def convert_row(row, schema):
+    t_schema = deepcopy(schema)
     to_return = {}
     for key, value in row.items():
-        if key in schema['properties']:
-            field_schema = schema['properties'][key]
-            declared_types = field_schema.get('type', 'string')
+        if key in t_schema['properties']:
+            field_schema = t_schema['properties'][key]
+            declared_types = field_schema.get('type', ['null', 'string'])
         else:
             declared_types = ['string','null']
 

--- a/tap_spreadsheets_anywhere/conversion.py
+++ b/tap_spreadsheets_anywhere/conversion.py
@@ -26,11 +26,11 @@ def coerce(datum,declared_types):
     if datum is None or datum == '':
         return None
 
-    desired_type = declared_types
-    if isinstance(declared_types, list):
-        if "null" in declared_types:
-            declared_types.remove("null")
-        desired_type = declared_types[0]
+    desired_type = declared_types.copy()
+    if isinstance(desired_type, list):
+        if "null" in desired_type:
+            desired_type.remove("null")
+        desired_type = desired_type[0]
 
     coerced, _ = convert(datum, desired_type)
     return coerced

--- a/tap_spreadsheets_anywhere/conversion.py
+++ b/tap_spreadsheets_anywhere/conversion.py
@@ -40,7 +40,7 @@ def convert(datum, desired_type=None):
     """
     Returns tuple of (converted_data_point, json_schema_type,).
     """
-    if datum is None or datum == '':
+    if datum is None or datum.strip() == '':
         return None, None,
 
     if desired_type in (None, 'integer'):

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -1,3 +1,4 @@
+import re
 import pytz
 from datetime import datetime, timezone
 


### PR DESCRIPTION
* Refactors write records to use Singer's Transformer() option for schema validation.
* Fixes bug where the original schema was being overwritten during `conversion.convert_row()` causing schema properties to no longer allow `null` values.
* Fixes bug where a blank string containing a space was not counting as `None`.